### PR TITLE
fix: nextjs incompatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,9 @@ export default defineConfig({
     },
     copyPublicDir: false,
     rollupOptions: {
-      external: ["react", "react-dom"],
+      external: (id) => {
+        return id === "react" || id === "react-dom" || id.startsWith("react/") || id.startsWith("react-dom/")
+      },
       output: {
         assetFileNames: "assets/[name][extname]",
         globals: {


### PR DESCRIPTION
The error occurs because the library was bundling React internally. When Next.js loads:

1. Next.js provides its own React instance
2. The library brings a bundled React copy
3. Result: Two React instances → `ReactCurrentDispatcher` conflict

The external config tells Vite: "Don't bundle React - the consuming app will provide it." This ensures only one React instance exists.

Closes https://github.com/HaithamLeo/accessibility-ui/issues/13